### PR TITLE
Setting Inverter Time and Ensuring time[] attributes are strings before concatenating them

### DIFF
--- a/solis_control.py
+++ b/solis_control.py
@@ -58,7 +58,18 @@ def prepare_header(config: dict[str,str], body: str, canonicalized_resource: str
 def control_body(inverterId, chargeSettings) -> str:
     body = '{"inverterId":"'+inverterId+'", "cid":"103","value":"'
     for index, time in enumerate(chargeSettings):
-        body = body +time['chargeCurrent']+","+time['dischargeCurrent']+","+time['chargeStartTime']+","+time['chargeEndTime']+","+time['dischargeStartTime']+","+time['dischargeEndTime']
+        body = body \
+          +str(time['chargeCurrent']) \
+          +"," \
+          +str(time['dischargeCurrent']) \
+          +"," \
+          +str(time['chargeStartTime']) \
+          +"," \
+          +str(time['chargeEndTime']) \
+          +"," \
+          +str(time['dischargeStartTime']) \
+          +"," \
+          +str(time['dischargeEndTime'])
         if (index !=2):
             body = body+","
     return body+'"}'

--- a/solis_control.py
+++ b/solis_control.py
@@ -74,8 +74,22 @@ def control_body(inverterId, chargeSettings) -> str:
             body = body+","
     return body+'"}'
 
-async def set_control_times(token, inverterId, config, times):
+def control_time_body(inverterId: str, currentTime: datetime) -> str:
+    body = '{"inverterId":"'+ inverterId + '", "cid":"56", "value":"' + \
+        currentTime.strftime('%Y-%m-%d %H:%M:%S') + \
+        + '"}'
+    
+    return body
+
+async def set_control_times(token, inverterId: str, config, times):
     body = control_body(inverterId, times)
+    headers = prepare_header(config, body, CONTROL_URL)
+    headers['token']= token
+    response = await session.post("https://www.soliscloud.com:13333"+CONTROL_URL, data = body, headers = headers)
+    log.warning("solis response:"+response.text())
+
+async def set_updated_time(token, inverterId: str, config, currentTime: datetime):
+    body = control_time_body(inverterId, currentTime)
     headers = prepare_header(config, body, CONTROL_URL)
     headers['token']= token
     response = await session.post("https://www.soliscloud.com:13333"+CONTROL_URL, data = body, headers = headers)
@@ -111,4 +125,5 @@ async def solis_control(config=None,days=None):
     inverterId= getInverterList(config)
     token = login(config)
     set_control_times(token, inverterId, config, days)
+    set_updated_time(token, inverterId, config, datetime.now())
     

--- a/solis_control.py
+++ b/solis_control.py
@@ -58,18 +58,7 @@ def prepare_header(config: dict[str,str], body: str, canonicalized_resource: str
 def control_body(inverterId, chargeSettings) -> str:
     body = '{"inverterId":"'+inverterId+'", "cid":"103","value":"'
     for index, time in enumerate(chargeSettings):
-        body = body \
-          +str(time['chargeCurrent']) \
-          +"," \
-          +str(time['dischargeCurrent']) \
-          +"," \
-          +str(time['chargeStartTime']) \
-          +"," \
-          +str(time['chargeEndTime']) \
-          +"," \
-          +str(time['dischargeStartTime']) \
-          +"," \
-          +str(time['dischargeEndTime'])
+        body = body +time['chargeCurrent']+","+time['dischargeCurrent']+","+time['chargeStartTime']+","+time['chargeEndTime']+","+time['dischargeStartTime']+","+time['dischargeEndTime']
         if (index !=2):
             body = body+","
     return body+'"}'


### PR DESCRIPTION
My inverter experiences quite a bit of time drift which messes with my charging schedule.  So now whenever the charge schedule is set/updated - the time on the inverter is as well.

I was running into issues when trying to set the various values as the value they were coming in from weren't strings (jinja templating horror).  I figured it was a good idea to ensure they're strings in Python as the failure I was getting was a python error that you can't concatenate an int/float type.

Error:
```
Exception in <file.solis_control.solis_control> line 59: body = body +time['chargeCurrent']+","+time['dischargeCurrent']+","+time['chargeStartTime']+","+time['chargeEndTime']+","+time['dischargeStartTime']+","+time['dischargeEndTime'] ^ TypeError: can only concatenate str (not "int") to str
Exception in <file.solis_control.solis_control> line 59: body = body +str(time['chargeCurrent'])+","+time['dischargeCurrent']+","+time['chargeStartTime']+","+time['chargeEndTime']+","+time['dischargeStartTime']+","+time['dischargeEndTime'] ^ TypeError: can only concatenate str (not "float") to str
```